### PR TITLE
move .tmux.conf to .config/tmux/tmux.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,10 @@ In order to make it work, simply copy the file `01-trackball.conf` into
 ## Installation
 
 Just run `./configure` at the root level of this repo.
+
+## Tmux post installation
+
+The `./configure` script is supposed to install the tmux plugin manager.
+All the plugins are declared in the tmux.conf file. However, at this step the plugins
+are not installed.
+We need to install them inside Tmux with the `PREFIX I` key binding

--- a/configure
+++ b/configure
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-CONFIG_FOLDERS=(i3 i3status kitty nvim yazi)
+CONFIG_FOLDERS=(i3 i3status kitty nvim yazi tmux)
 
 for config_folder in "${CONFIG_FOLDERS[@]}"; do
   TARGET_FOLDER="$HOME"/.config/"$config_folder"
@@ -55,4 +55,17 @@ else
   stow --dir rofi share --target "$ROFI_SHARE_DIRECTORY"
 
   echo "rofi share stowed"
+fi
+
+TPM_PATH=$HOME/.config/tmux/plugins/tpm
+TPM_REMOTE_REPOSITORY=https://github.com/tmux-plugins/tpm
+
+echo "Checking Tmux Plugin Manager is installed"
+if [ -e "$TPM_PATH" ]; then
+  echo "Tmux Plugin Manager already installed. Updating..."
+  git -c $TPM_PATH pull
+else
+  echo "Tmux Plugin Manager not installed. Installing..."
+
+  git clone $TPM_REMOTE_REPOSITORY $TPM_PATH
 fi

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -1,5 +1,5 @@
 unbind r
-bind r source-file ./.tmux.conf
+bind r source-file $HOME/.config/tmux/tmux.conf
 
 # First window has index one.
 set -g base-index 1
@@ -60,4 +60,4 @@ set -g @catppuccin_directory_text "#{pane_current_path}"
 # set -g @plugin 'git@github.com:user/plugin'
 # set -g @plugin 'git@bitbucket.com:user/plugin'
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
-run '~/.tmux/plugins/tpm/tpm'
+run '~/.config/tmux/plugins/tpm/tpm'


### PR DESCRIPTION
In order to stay consistent with other configs, we decide to place the tmux configuration inside the `.config` directory among other configs. It's supported by tmux itself natively so we have a better consistency like this.

Also in the `configure` script we install the Tmux plugin manager automatically.