### PR TITLE
environment specific configuration files (i3)

### DIFF
--- a/i3/config
+++ b/i3/config
@@ -33,8 +33,10 @@ exec --no-startup-id dex-autostart --autostart --environment i3
 # screen before suspend. Use loginctl lock-session to lock your screen.
 exec --no-startup-id xss-lock --transfer-sleep-lock -- i3lock --nofork
 
-# nice background TODO: use a symlink here to change easily
-exec_always feh --bg-fill ~/Downloads/wp9994268-caspar-david-friedrich-wallpapers.jpg
+# In order to have specific configuration for a local environment,
+# You can add an additional file in the `config.d/` directory
+# This directory is gitignored so we can decouple the config we want to share between environments from the config that is environment specific.
+include ~/.config/i3/config.d/*.conf
 
 # i3lock
 bindsym $mod+o exec i3lock


### PR DESCRIPTION
In order to stay consistent with other configs, we decide to place the tmux configuration inside the `.config` directory among other configs. It's supported by tmux itself natively so we have a better consistency like this.

Also in the `configure` script we install the Tmux plugin manager automatically.